### PR TITLE
Update jquery.columnview.js

### DIFF
--- a/jquery.columnview.js
+++ b/jquery.columnview.js
@@ -263,6 +263,13 @@ jQuery.fn.mapAttributes = function(prefix) {
 
       if ($target.is("a,span")) {
         if ($target.is("span")){
+	  /** 
+	  * Retrieve the master <span> for strucure like:
+	  * <span class='label'><span class="code">...</span> - <span class="text">...</span></span>
+	  */
+          while($target.parent().is('span')) {
+            $target = $target.parent();
+          }
           $self = $target.parent();
         }
         else {


### PR DESCRIPTION
Hello,

I was in trouble using this very good jquery plugin.
I need to put some children <span> into the each link. 
<a href="#"><span class="code">...</span> - <span class="text">...</span></a>

This leads to a bad span map. Here is the code to assure that the correct master span.label is retrieved.

Thanks
Alexandre
